### PR TITLE
Removed dysfunctional PlayerBlockTracker, fixed new dupe exploit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.unitedlands</groupId>
     <artifactId>UnitedSkills</artifactId>
-    <version>3.6.10</version>
+    <version>3.6.11</version>
     <packaging>jar</packaging>
 
     <name>UnitedSkills</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.unitedlands</groupId>
     <artifactId>UnitedSkills</artifactId>
-    <version>3.6.9b</version>
+    <version>3.6.10</version>
     <packaging>jar</packaging>
 
     <name>UnitedSkills</name>
@@ -100,8 +100,13 @@
         <dependency>
             <groupId>com.github.Zrips</groupId>
             <artifactId>Jobs</artifactId>
-            <version>v4.17.2</version>
+            <version>v5.2.4.5</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.Zrips</groupId>
+            <artifactId>CMILib</artifactId>
+            <version>1.4.7.4</version>
         </dependency>
         <dependency>
             <groupId>com.craftaro.ultimatetimber</groupId>
@@ -130,12 +135,6 @@
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
             <version>2.10.9</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.Flo0</groupId>
-            <artifactId>PlayerBlockTracker</artifactId>
-            <version>1.0.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/unitedlands/skills/Utils.java
+++ b/src/main/java/org/unitedlands/skills/Utils.java
@@ -3,7 +3,6 @@ package org.unitedlands.skills;
 import com.gamingmesh.jobs.Jobs;
 import com.gamingmesh.jobs.container.JobProgression;
 import com.gamingmesh.jobs.container.JobsPlayer;
-import com.gestankbratwurst.playerblocktracker.PlayerBlockTracker;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bukkit.Bukkit;
@@ -24,7 +23,8 @@ public class Utils {
     @NotNull
     public static Component getMessage(String message) {
         String configMessage = getUnitedSkills().getConfig().getString("messages." + message);
-        return miniMessage.deserialize(Objects.requireNonNullElseGet(configMessage, () -> "<red>Message <yellow>" + message + "<red> could not be found in the config file!"));
+        return miniMessage.deserialize(Objects.requireNonNullElseGet(configMessage,
+                () -> "<red>Message <yellow>" + message + "<red> could not be found in the config file!"));
     }
 
     public static UnitedSkills getUnitedSkills() {
@@ -39,10 +39,12 @@ public class Utils {
 
     public static boolean takeItemFromMaterial(@NotNull Player player, @NotNull Material material) {
         int slot = player.getInventory().first(material);
-        if (slot < 0) return false;
+        if (slot < 0)
+            return false;
 
         ItemStack item = player.getInventory().getItem(slot);
-        if (item == null || item.getType().isAir()) return false;
+        if (item == null || item.getType().isAir())
+            return false;
 
         item.setAmount(item.getAmount() - 1);
         return true;
@@ -52,11 +54,13 @@ public class Utils {
         Inventory inventory = player.getInventory();
 
         int slot = inventory.first(item.getType());
-        if (slot < 0) return false;
+        if (slot < 0)
+            return false;
 
         for (int i = 0; i < inventory.getSize(); i++) {
             ItemStack itemInInventory = inventory.getItem(i);
-            if (itemInInventory == null || itemInInventory.getType().isAir()) continue;
+            if (itemInInventory == null || itemInInventory.getType().isAir())
+                continue;
             if (itemInInventory.getType().equals(item.getType())) {
                 if (itemInInventory.getItemMeta().equals(item.getItemMeta())) {
                     itemInInventory.setAmount(itemInInventory.getAmount() - 1);
@@ -67,17 +71,31 @@ public class Utils {
         return false;
     }
 
-    public static boolean isPlaced(Block block) {
-        return PlayerBlockTracker.isTracked(block);
+    // public static boolean isPlaced(Block block) {
+    // return PlayerBlockTracker.isTracked(block);
+    // }
+
+    public static Boolean wasRecentlyPlaced(Block block) {
+        var placeTime = Jobs.getExploitManager().getTime(block);
+        if (placeTime != null)
+            // Naturally spawned blocks always return a time difference of 2000-3000ms, make
+            // sure to stay above that.
+            if (placeTime - System.currentTimeMillis() > 3000)
+                return true;
+        return false;
     }
 
     public static boolean canActivate(PlayerInteractEvent event, String materialKeyword, ActiveSkill skill) {
-        if (event.getItem() == null) return false;
-        if (!event.getAction().isRightClick()) return false;
+        if (event.getItem() == null)
+            return false;
+        if (!event.getAction().isRightClick())
+            return false;
 
         Player player = event.getPlayer();
-        if (!player.isSneaking()) return false;
-        if (!event.getItem().getType().toString().contains(materialKeyword)) return false;
+        if (!player.isSneaking())
+            return false;
+        if (!event.getItem().getType().toString().contains(materialKeyword))
+            return false;
         return skill.getLevel() != 0;
     }
 

--- a/src/main/java/org/unitedlands/skills/Utils.java
+++ b/src/main/java/org/unitedlands/skills/Utils.java
@@ -77,11 +77,16 @@ public class Utils {
 
     public static Boolean wasRecentlyPlaced(Block block) {
         var placeTime = Jobs.getExploitManager().getTime(block);
-        if (placeTime != null)
-            // Naturally spawned blocks always return a time difference of 2000-3000ms, make
+        if (placeTime != null) {
+            // Naturally spawned blocks always return global break time, make
             // sure to stay above that.
-            if (placeTime - System.currentTimeMillis() > 3000)
+            getUnitedSkills().getLogger().info("t1:" + placeTime + ", t2: " + System.currentTimeMillis() + ", d: " + (placeTime - System.currentTimeMillis()));
+            if (placeTime - System.currentTimeMillis() > 60000)
                 return true;
+        }
+        else {
+            getUnitedSkills().getLogger().info("t1: NULL");
+        }
         return false;
     }
 

--- a/src/main/java/org/unitedlands/skills/Utils.java
+++ b/src/main/java/org/unitedlands/skills/Utils.java
@@ -80,12 +80,8 @@ public class Utils {
         if (placeTime != null) {
             // Naturally spawned blocks always return global break time, make
             // sure to stay above that.
-            getUnitedSkills().getLogger().info("t1:" + placeTime + ", t2: " + System.currentTimeMillis() + ", d: " + (placeTime - System.currentTimeMillis()));
             if (placeTime - System.currentTimeMillis() > 60000)
                 return true;
-        }
-        else {
-            getUnitedSkills().getLogger().info("t1: NULL");
         }
         return false;
     }

--- a/src/main/java/org/unitedlands/skills/abilities/DiggerAbilities.java
+++ b/src/main/java/org/unitedlands/skills/abilities/DiggerAbilities.java
@@ -58,13 +58,13 @@ public class DiggerAbilities implements Listener {
             return;
         }
 
-        var block = event.getBlock();
-        if (wasRecentlyPlaced(block)) {
-            return;
-        }
-        
         Skill mineralFinder = new Skill(player, SkillType.MINERAL_FINDER);
         if (mineralFinder.getLevel() == 0) {
+            return;
+        }
+
+        var block = event.getBlock();
+        if (wasRecentlyPlaced(block)) {
             return;
         }
 
@@ -85,13 +85,13 @@ public class DiggerAbilities implements Listener {
             return;
         }
 
-        var block = event.getBlock();
-        if (wasRecentlyPlaced(block)) {
+        Skill archaeologist = new Skill(player, SkillType.ARCHAEOLOGIST);
+        if (archaeologist.getLevel() == 0) {
             return;
         }
 
-        Skill archaeologist = new Skill(player, SkillType.ARCHAEOLOGIST);
-        if (archaeologist.getLevel() == 0) {
+        var block = event.getBlock();
+        if (wasRecentlyPlaced(block)) {
             return;
         }
 
@@ -111,12 +111,11 @@ public class DiggerAbilities implements Listener {
             return;
         }
 
-        if (wasRecentlyPlaced(event.getBlock())) {
-            return;
-        }
-
         Skill excavator = new Skill(player, SkillType.EXCAVATOR);
         if (excavator.isSuccessful()) {
+            if (wasRecentlyPlaced(event.getBlock())) {
+                return;
+            }
             List<Item> items = event.getItems();
             for (Item item : items) {
                 if (Objects.requireNonNull(unitedSkills.getConfig().getList("excavator-items"))

--- a/src/main/java/org/unitedlands/skills/abilities/MinerAbilities.java
+++ b/src/main/java/org/unitedlands/skills/abilities/MinerAbilities.java
@@ -82,11 +82,6 @@ public class MinerAbilities implements Listener {
             return;
         }
 
-        var block = event.getBlock();
-        if (wasRecentlyPlaced(block)) {
-            return;
-        }
-
         ItemStack pickaxe = player.getInventory().getItemInMainHand();
         String materialName = event.getBlockState().getType().toString();
         // Ores should not duplicate if the user has silk touch.
@@ -97,6 +92,10 @@ public class MinerAbilities implements Listener {
         Skill fortunate = new Skill(player, SkillType.FORTUNATE);
         List<Item> items = event.getItems();
         if (fortunate.isSuccessful()) {
+            if (wasRecentlyPlaced(event.getBlock())) {
+                return;
+            }
+    
             for (Item item : items) {
                 if (materialName.contains("_ORE")) {
                     Utils.multiplyItem(player, item.getItemStack(), 1);

--- a/src/main/java/org/unitedlands/skills/abilities/MinerAbilities.java
+++ b/src/main/java/org/unitedlands/skills/abilities/MinerAbilities.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.unitedlands.skills.Utils.canActivate;
+import static org.unitedlands.skills.Utils.wasRecentlyPlaced;
 
 public class MinerAbilities implements Listener {
     private final UnitedSkills unitedSkills;
@@ -81,8 +82,8 @@ public class MinerAbilities implements Listener {
             return;
         }
 
-        Block block = event.getBlock();
-        if (Utils.isPlaced(block)) {
+        var block = event.getBlock();
+        if (wasRecentlyPlaced(block)) {
             return;
         }
 

--- a/src/main/java/org/unitedlands/skills/abilities/WoodcutterAbilities.java
+++ b/src/main/java/org/unitedlands/skills/abilities/WoodcutterAbilities.java
@@ -123,10 +123,11 @@ public class WoodcutterAbilities implements Listener {
         if (!material.toString().contains("LOG")) {
             return;
         }
-        if (isPlaced(event.getBlock())) {
+        var block = event.getBlock();
+        if (wasRecentlyPlaced(block)) {
             return;
         }
-
+        
         // Perform towny check to see if player is allowed to break blocks in that location
         if (!PlayerCacheUtil.getCachePermission(player, event.getBlock().getLocation(), event.getBlock().getType(),
                 TownyPermission.ActionType.DESTROY)) {

--- a/src/main/java/org/unitedlands/skills/abilities/WoodcutterAbilities.java
+++ b/src/main/java/org/unitedlands/skills/abilities/WoodcutterAbilities.java
@@ -123,11 +123,7 @@ public class WoodcutterAbilities implements Listener {
         if (!material.toString().contains("LOG")) {
             return;
         }
-        var block = event.getBlock();
-        if (wasRecentlyPlaced(block)) {
-            return;
-        }
-        
+
         // Perform towny check to see if player is allowed to break blocks in that location
         if (!PlayerCacheUtil.getCachePermission(player, event.getBlock().getLocation(), event.getBlock().getType(),
                 TownyPermission.ActionType.DESTROY)) {
@@ -135,6 +131,9 @@ public class WoodcutterAbilities implements Listener {
         }
 
         if (precisionCutting.isSuccessful()) {
+            if (wasRecentlyPlaced(event.getBlock())) {
+                return;
+            }
             multiplyItem(player, new ItemStack(material), 2);
         }
     }


### PR DESCRIPTION
PlayerBlockTracker silently became outdated and stopped tracking player placed blocks entirely, leading to possible exploit with Precision Cutting, Fortunate and Excavator skills.

Swapped PlayerBlockTracker checks with Jobs-internal ExploitManager methods to sync skill activations with Jobs payments.

(This time with correct timings)