### PR TITLE
Frenzy dupe hotfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.unitedlands</groupId>
     <artifactId>UnitedSkills</artifactId>
-    <version>3.6.12</version>
+    <version>3.6.13</version>
     <packaging>jar</packaging>
 
     <name>UnitedSkills</name>

--- a/src/main/java/org/unitedlands/skills/abilities/MinerAbilities.java
+++ b/src/main/java/org/unitedlands/skills/abilities/MinerAbilities.java
@@ -108,7 +108,7 @@ public class MinerAbilities implements Listener {
             List<String> whitedlistedMaterials = unitedSkills.getConfig().getStringList("frenzy-whitelist");
             for (Item item : items) {
                 // Only duplicate whitelisted materials.
-                if (whitedlistedMaterials.contains(materialName)) {
+                if (whitedlistedMaterials.contains(item.getItemStack().getType().toString())) {
                     Utils.multiplyItem(player, item.getItemStack(), 3);
                 }
             }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -727,7 +727,16 @@ frenzy-whitelist:
   - CALCITE
   - BASALT
   - BLACKSTONE
-
+  - DIAMOND
+  - RAW_IRON
+  - RAW_COPPER
+  - RAW_GOLD
+  - LAPIS_LAZULI
+  - COAL
+  - REDSTONE
+  - EMERALD
+  - COBBLESTONE
+  - COBBLED_DEEPSLATE
 messages:
   no-permission: "You do not have permission to execute this command!"
   must-be-hunter: "<red>You must be a hunter to use this mob net!"


### PR DESCRIPTION
Switched Frenzy whitelist check to dropped items (instead of breaking block) to remove possible duping expolit for auto-breaking entities